### PR TITLE
Snipe a name & skip the menu with python3 snipe.py [name] snipe/block [delay]

### DIFF
--- a/snipe.py
+++ b/snipe.py
@@ -7,12 +7,16 @@ from os import path
 import time
 from bs4 import BeautifulSoup
 import json
+import sys
 
 init()
 
 logging.basicConfig(level=logging.INFO, format='%(message)s')
 times = []
 
+target_username = sys.argv[1]
+block_snipe = int(sys.argv[2])
+snipe_delay = int(sys.argv[3])
 
 def custom_info(message):
     logging.info(f"{Fore.BLUE}[info] {Fore.RESET}{message}")
@@ -264,10 +268,11 @@ def load_accounts():
 class session:
     block_snipe = ["Snipe", "block"]
 
-    def __init__(self, target_username, accounts, block_snipe):
+    def __init__(self, target_username, accounts, block_snipe, snipe_delay):
         self.target_username = target_username
         self.accounts = accounts
         self.block_snipe = block_snipe
+        self.snipe_delay = snipe_delay
         loop = asyncio.get_event_loop()
         self.drop_time = loop.run_until_complete(time_snipe(self.target_username, self.block_snipe))
         self.setup_time = self.drop_time - timedelta(seconds=50)
@@ -275,7 +280,7 @@ class session:
         self.ran = False
         self.settings_json = json.loads(open("settings.json", "r").read())
         if self.settings_json["custom_delay"]:
-            self.drop_time = self.drop_time - timedelta(milliseconds=int(custom_input("Custom delay in ms: ")))
+            self.drop_time = self.drop_time - timedelta(milliseconds=self.snipe_delay)
         else:
             if self.block_snipe == 0:
                 self.drop_time = self.drop_time - timedelta(milliseconds=900)
@@ -338,6 +343,5 @@ class session:
 
 print_title()
 accounts = load_accounts()
-block_snipe, target_username = gather_info()
-session = session(target_username, accounts, block_snipe)
+session = session(target_username, accounts, block_snipe, snipe_delay)
 session.run()

--- a/snipe.py
+++ b/snipe.py
@@ -14,10 +14,6 @@ init()
 logging.basicConfig(level=logging.INFO, format='%(message)s')
 times = []
 
-target_username = sys.argv[1]
-block_snipe = int(sys.argv[2])
-snipe_delay = int(sys.argv[3])
-
 def custom_info(message):
     logging.info(f"{Fore.BLUE}[info] {Fore.RESET}{message}")
 
@@ -280,7 +276,10 @@ class session:
         self.ran = False
         self.settings_json = json.loads(open("settings.json", "r").read())
         if self.settings_json["custom_delay"]:
-            self.drop_time = self.drop_time - timedelta(milliseconds=self.snipe_delay)
+            if self.snipe_delay == "not specified":
+                self.drop_time = self.drop_time - timedelta(milliseconds=int(custom_input("Custom delay in ms: ")))
+            else:
+                self.drop_time = self.drop_time - timedelta(milliseconds=self.snipe_delay)
         else:
             if self.block_snipe == 0:
                 self.drop_time = self.drop_time - timedelta(milliseconds=900)
@@ -343,5 +342,16 @@ class session:
 
 print_title()
 accounts = load_accounts()
+try:
+    target_username = sys.argv[1]
+    block_snipe = sys.argv[2]
+    if str(block_snipe).lower() == "snipe" or str(block_snipe) == "0":
+        block_snipe = 0
+    if str(block_snipe).lower() == "block" or str(block_snipe) == "1":
+        block_snipe = 1
+    snipe_delay = int(sys.argv[3])
+except:
+    block_snipe, target_username = gather_info()
+    snipe_delay = "not specified"
 session = session(target_username, accounts, block_snipe, snipe_delay)
 session.run()


### PR DESCRIPTION
Can be very convenient for multiple VPS users since we'd only have to copy-paste one command for all machines. It might also allow discord.py bots to snipe names with paramiko, but this requires testing.